### PR TITLE
Added a signed version of hash_fp

### DIFF
--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -128,6 +128,13 @@ namespace Simhash {
             return hash;
         }
 
+        /* As above, but operate on a vector of signed 64-bit integers. For
+         * some language bindings, casting and function overloading can be
+         * difficult to use, which is why it's given a new name */
+        hash_t hash_fps(int64_t *vec, int len) {
+            return hash_fp(reinterpret_cast<uint64_t*>(vec), len);
+        }
+
     private:
         /* Internal stuffs */
         hash_type      hasher;


### PR DESCRIPTION
This is important for using `hash_fp` from Cython.
