### PR TITLE
Fixed bug in test.

### DIFF
--- a/src/test.cpp
+++ b/src/test.cpp
@@ -111,7 +111,7 @@ TEST_CASE("tokenizers", "We can get tokens from a string") {
         for (size_t i = 0; i < 12; ++i) {
             next = tokenizer(current);
             REQUIRE((next - current) == expected[i]);
-            current = next + 1;
+            current = next + (*next != '\0');
         }
 
         /* Now we should be at the end */


### PR DESCRIPTION
Got the following error message while executing the tests:

```
>./test
[Started testing]

[Running: tokenizers]

[Started section: 'strspn']
test.cpp:119: (next == __null) failed for: false
[End of section: 'strspn' 1 of 13 assertions failed]

[Finished: 'tokenizers' 1 test case failed (1 of 13 assertions failed)]

[Testing completed. 1 of 3 test cases failed (1 of 31 assertions failed)]
```

The current pointer in the code was actually moved one position to the
right of the terminal `\0` character of the const char string.
Probably the test passed for others, since the memory after the string
was filled with `\0` bytes.