### PR TITLE
Fixed undefined usage of right-shift (shifting by 64), which resulted…

### DIFF
--- a/src/cyclic.hpp
+++ b/src/cyclic.hpp
@@ -51,7 +51,7 @@ namespace Simhash {
 
         static inline hash_type rotate(hash_type v, size_t count) {
             count = count % bits;
-            return (v << count) | (v >> (bits - count));
+            return (v << count) | (v >> ((bits - count)%bits) );
         }
     private:
         size_t    length;  // How many pieces of data to store

--- a/src/simhash.h
+++ b/src/simhash.h
@@ -41,7 +41,11 @@ namespace Simhash {
              * @param j - pointer to a Judy array
              * @param l - value of element to start at */
             const_iterator_t(void* j, hash_t l):
-                judy(j), results(1), last(l) {};
+                judy(j), results(1), last(l) {
+                    //Make sure we immediately populate last, 
+                    //otherwise we get a 0 on first acces
+                    J1F(results, judy, last);
+                };
             
             /** Copy constructor */
             const_iterator_t(const const_iterator_t& other):
@@ -99,6 +103,10 @@ namespace Simhash {
             }
             
             bool operator!=(const const_iterator_t& other) {
+                // We need to check this here as well otherwise we fail.
+                if (!results && !other.results) {
+                    return false;
+                }
                 // They've both reached their invalid ranges
                 return last != other.last;
             }
@@ -236,7 +244,7 @@ namespace Simhash {
             /**
              * Return an iterator to just past the end of this container */
             const_iterator end() {
-                return --const_iterator(judy, std::numeric_limits<hash_t>::max());
+                return const_iterator(judy, std::numeric_limits<hash_t>::max());
             }
 
             /**


### PR DESCRIPTION
The rotation was failing in some cases because right-shift was being called with a shift of 64, where it was assumed the result would be 0, but is actually undefined according to the spec (the shift value has to be strictly smaller than the size in bits of the variable type).

Also fixed the iterator to access the tables, which did not work properly (dereferencing the first time always returns 0 because J1F/J1N is never called, and trying to iterate through an empty table caused an infinite loop). 