### PR TITLE
Fix missing invocation of `Cyclic#push`.

### DIFF
--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -38,6 +38,7 @@ namespace Simhash {
             Accumulator() : window(3), cyclic(window), v(BITS, 0) {}
 
             void update(hash_t hash) {
+                hash = cyclic.push(hash);
                 for (int j = (BITS - 1); j >= 0; --j) {
                     v[j] += (hash & 1) ? 1 : -1;
                     hash >>= 1;


### PR DESCRIPTION
This call got dropped in the refactor done in 127c95c39c8c35accf930096fd86dbd2cde30481.

If you look closely here:

https://github.com/seomoz/simhash-cpp/blob/127c95c39c8c35accf930096fd86dbd2cde30481%5E/src/hash.hpp#L69-L73

You'll notice that this loop became `Accumulator#update`. However, in the [old code](https://github.com/seomoz/simhash-cpp/blob/127c95c39c8c35accf930096fd86dbd2cde30481%5E/src/hash.hpp#L68) `Cyclic#push` was being invoked on the result from `hasher`, but in the [new code](https://github.com/seomoz/simhash-cpp/blob/127c95c39c8c35accf930096fd86dbd2cde30481/src/hash.hpp#L111) `Accumulator#update` is being passed the result of `hasher` directly. 

Note that this was clearly an oversight in the prior refactoring because the `cyclic` member is constructed, but never actually used in the current `Accumulator` code.