### PR TITLE
Ignore empty tokens.

### DIFF
--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -74,7 +74,10 @@ namespace Simhash {
             Accumulator accumulator;
 
             for (char **tp = tokens; *tp != NULL; ++tp) {
-                accumulator.update(hasher(*tp, strlen(*tp), 0));
+                size_t len = strlen(*tp);
+                if (len > 0) {
+                    accumulator.update(hasher(*tp, len, 0));
+                }
             }
 
             return accumulator.result();
@@ -109,7 +112,9 @@ namespace Simhash {
             for (const char *current = string, *next = tokenizer(current)
                 ; next != NULL
                 ; next = tokenizer(current)) {
-                accumulator.update(hasher(current, next - current, 0));
+                if (next != current) {
+                    accumulator.update(hasher(current, next - current, 0));
+                }
                 current = next + 1;
             }
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -158,7 +158,7 @@ TEST_CASE("We can perform simhash", "[simhash]") {
         Simhash::Simhash<> hasher;
         uint64_t a = hasher.hash_tokenizer(jabberwocky.c_str(), Simhash::Strspn());
         /* Update jabberwocky to include who wrote it */
-        jabberwocky += " - Lewis Carroll in 'Alice In Wonderland'";
+        jabberwocky += " - Lewis Carroll 'Alice In Wonderland'";
         uint64_t b = hasher.hash_tokenizer(jabberwocky.c_str(), Simhash::Strspn());
 
         /* Now, make sure that the number of bits by which they differ is


### PR DESCRIPTION
This was lost in change cbdcfaf.

It's similar in nature to #24. The [original code](https://github.com/seomoz/simhash-cpp/blob/eebfb4571068f15992c7a701022518280f813f9d/src/hash.hpp#L72-L84) skipped over empty tokens in the input string and didn't count them towards the hash. The [new code](https://github.com/seomoz/simhash-cpp/blob/cbdcfaf6347221597463e91576a731db837254dd/src/hash.hpp#L67-L75) was not careful and blindly included empty tokens.