### PR TITLE
Switch to using precise (12.04) as base image for Vagrant.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 
 # http://docs.vagrantup.com/v2/
 Vagrant.configure('2') do |config|
-  config.vm.box = 'ubuntu/trusty64'
+  config.vm.box = 'ubuntu/precise64'
   config.vm.hostname = 'simhash-cpp'
   config.ssh.forward_agent = true
 


### PR DESCRIPTION
Libjudy appears to have issues with newer versions of GCC.

See seomoz/simhash-py#8 for more details.