### PR TITLE
BIG-4336 - Clustering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ release/
 *.gcda
 *.gcno
 *.gcov
+coverage.out
 
 # Vagrant
 .vagrant/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CXX          ?= g++
 CXXOPTS      ?= -g -Wall -Werror -std=c++11 -Iinclude/
 DEBUG_OPTS   ?= -fprofile-arcs -ftest-coverage -O0 -fPIC
 RELEASE_OPTS ?= -O3
-BINARIES      = release/bin/simhash-find-all
+BINARIES      = release/bin/simhash-find-all release/bin/simhash-find-clusters
 
 all: test release/libsimhash.o $(BINARIES)
 
@@ -10,24 +10,19 @@ all: test release/libsimhash.o $(BINARIES)
 release:
 	mkdir -p release
 
-release/bin: release
-	mkdir -p release/bin
-
 release/libsimhash.o: release/simhash.o release/permutation.o
 	ld -r -o $@ $^
 
 release/%.o: src/%.cpp include/%.h release
 	$(CXX) $(CXXOPTS) $(RELEASE_OPTS) -o $@ -c $<
 
-release/bin/simhash-find-all: src/bin/simhash-find-all.cpp release/libsimhash.o
+release/bin/%: src/bin/%.cpp release/libsimhash.o
+	mkdir -p release/bin
 	$(CXX) $(CXXOPTS) $(RELEASE_OPTS) -o $@ $^
 
 # Debug libraries
 debug:
 	mkdir -p debug
-
-debug/bin: debug
-	mkdir -p debug/bin
 
 debug/libsimhash.o: debug/simhash.o debug/permutation.o
 	ld -r -o $@ $^
@@ -35,7 +30,8 @@ debug/libsimhash.o: debug/simhash.o debug/permutation.o
 debug/%.o: src/%.cpp include/%.h debug
 	$(CXX) $(CXXOPTS) $(DEBUG_OPTS) -o $@ -c $<
 
-debug/bin/simhash-find-all: src/bin/simhash-find-all.cpp debug/libsimhash.o debug/bin
+debug/bin/%: src/bin/%.cpp debug/libsimhash.o debug/bin
+	mkdir -p debug/bin
 	$(CXX) $(CXXOPTS) $(DEBUG_OPTS) -o $@ $^
 
 test/%.o: test/%.cpp

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ test-all: test/test-all.o test/test-simhash.o test/test-permutation.o debug/libs
 .PHONY: test
 test: test-all
 	./test-all
+	./scripts/check-coverage.sh $(PWD)
 
 clean:
 	rm -rf debug release test-all bench

--- a/README.md
+++ b/README.md
@@ -21,21 +21,30 @@ non-alpha characters.
 ![Open Source: Yes](https://img.shields.io/badge/open_source-MIT-green.svg?style=flat)
 ![Critical: Yes](https://img.shields.io/badge/critical-yes-red.svg?style=flat)
 
-Building
-========
-For those curious about testing performance, you can run the benchmark. It
-performs a number of insertions into the query data structure, and then
-performs 4 queries for each of those inserted fingerprints. Provide a number as
-the first argument on the command line to change the number of items inserted.
-To be clear, __this is done on merely one of the tables needed to perform
-simhash queries__.
-
-    ./bench 10000000
-
 Usage
 =====
-I'll work on this documentation as time permits, but for the time being, refer
-to the source and `bench.cpp`.
+
+Library
+-------
+The library provides two utilities for finding simhashes:
+
+- `Simhash::find_all` finds all matching pairs of simhashes
+- `Simhash::find_clusters` finds clusters of matching simhashes (see `#clustering`)
+
+Binaries
+--------
+This also provides two binaries to facilitate use from other languages. They both read
+hashes as newline-separated decimal strings, and print out newline-separated JSON arrays.
+
+- `simhash-find-all` writes all matching pairs as arrays with two elements
+- `simhash-find-clusters` writes all clusters as arrays of simhashes
+
+Both have the following common arguments:
+
+- `--input` names a file from which to read (defaults to `-`, meaning `stdin`)
+- `--output` names a file to which to write (defaults to `-`, meaning `stdout`)
+- `--blocks` sets the number of blocks to use for simhash matching
+- `--distance` sets the maximum bit distance for considering matches
 
 Architecture
 ============
@@ -102,3 +111,15 @@ scan. In this case, the table that's permuted `A C F B D E` will match. It's
 important to note that it's possible for a query to match from more than one
 table. For example, if two of the non-matching bits are in the same block, or
 the query differs by fewer than 3 bits.
+
+Clustering
+==========
+The current clustering implementation considers the clusters to be the connected
+components of the connectivity graph. In other words:
+
+    For a simhash to be a member of a cluster, it must be a match with at least one
+    member of that cluster.
+
+This does mean that a cluster may have pairs of members that aren't matches. For
+examples, (`A, B, C, D`) might be a cluster where `A` matches `B`, which matches
+`C`, which matches `D`, but `A` and `D` are too far apart to be a match.

--- a/include/simhash.h
+++ b/include/simhash.h
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <stdint.h>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -34,6 +35,11 @@ namespace Simhash {
     typedef std::unordered_set<match_t, match_t_hash> matches_t;
 
     /**
+     * The type of a set of clusters.
+     */
+    typedef std::vector<std::unordered_set<hash_t> > clusters_t;
+
+    /**
      * The number of bits in a hash_t.
      */
     static const size_t BITS = sizeof(hash_t) * 8;
@@ -61,6 +67,16 @@ namespace Simhash {
     matches_t find_all(std::unordered_set<hash_t>& hashes,
                        size_t number_of_blocks,
                        size_t different_bits);
+
+    /**
+     * Find all the clusters of simhashes.
+     *
+     * For a simhash to be added to a cluster, there must be a member in the
+     * cluster already that is within `number_of_blocks` of the hash.
+     */
+    clusters_t find_clusters(std::unordered_set<hash_t>& hashes,
+                             size_t number_of_blocks,
+                             size_t different_bits);
 }
 
 #endif

--- a/provision.sh
+++ b/provision.sh
@@ -4,7 +4,10 @@ set -e
 
 # Some dependencies
 sudo apt-get update
-sudo apt-get install -y make g++ gdb git cmake libgtest-dev clang-3.5
+sudo apt-get install -y make g++ gdb git cmake libgtest-dev clang-3.5 python-pip
+
+# For coverage
+sudo pip install gcovr==3.2
 
 pushd /usr/src/gtest
     sudo CXX=g++ CC=gcc cmake CMakeLists.txt

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,0 +1,35 @@
+#! /usr/bin/env bash
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage:"
+    echo "    check-coverage.sh <path-to-project-root>"
+    exit 1
+fi
+
+root="${1}"
+
+results=`gcovr \
+    --root=${root} \
+    --exclude-unreachable-branches \
+    --output=coverage.out \
+    --print-summary \
+    --object-directory=${root} \
+    --exclude test \
+    --exclude src/bin`
+
+lines=`echo ${results} | sed -E 's#^.*lines: ([0-9]+)(\.[0-9]+)?%.+$#\1#'`
+branches=`echo ${results} | sed -E 's#^.*branches: ([0-9]+)(\.[0-9]+)?%.+$#\1#'`
+
+if [ "${lines}" -eq "0" ]; then
+    echo "Coverage disabled."
+    echo "#{results}"
+elif [ "${lines}" -ne "100" ]; then
+    echo "Incomplete line coverage (${lines})"
+    echo "${results}"
+    exit 2
+else
+    echo "Coverage looks good!"
+    echo "${results}"
+fi

--- a/src/bin/simhash-find-all.cpp
+++ b/src/bin/simhash-find-all.cpp
@@ -26,18 +26,9 @@ void usage(int argc, char** argv)
 std::unordered_set<Simhash::hash_t> read_hashes(std::istream& stream)
 {
     std::unordered_set<Simhash::hash_t> hashes;
-    Simhash::hash_t hash(0);
-    while (!stream.eof())
+    for (std::string line; std::getline(stream, line); )
     {
-        stream.read(reinterpret_cast<char*>(&hash), sizeof(hash));
-        if (!stream.fail())
-        {
-            hashes.insert(hash);
-        }
-        else
-        {
-            break;
-        }
+        hashes.insert(std::stoull(line));
     }
     return hashes;
 }
@@ -46,10 +37,7 @@ void write_matches(std::ostream& stream, const Simhash::matches_t& matches)
 {
     for (auto it = matches.begin(); it != matches.end() && !std::cout.fail(); ++it)
     {
-        stream.write(
-            reinterpret_cast<const char*>(&(it->first)), sizeof(Simhash::hash_t));
-        stream.write(
-            reinterpret_cast<const char*>(&(it->second)), sizeof(Simhash::hash_t));
+        stream << "[" << it->first << ", " << it->second << "]\n";
     }
     stream.flush();
 }

--- a/src/bin/simhash-find-clusters.cpp
+++ b/src/bin/simhash-find-clusters.cpp
@@ -1,0 +1,191 @@
+#include <iostream>
+#include <unordered_set>
+#include <sstream>
+#include <fstream>
+
+#include <getopt.h>
+
+#include "simhash.h"
+
+void usage(int argc, char** argv)
+{
+    std::cout << "usage: " << argv[0]
+              << " --blocks BLOCKS"
+              << " --distance DISTANCE"
+              << " --input INPUT"
+              << " --output OUTPUT\n\n"
+              << "Read simhashes from input, finds all clusters using the provided \n"
+              << "distance threshold, writing them to output.\n\n"
+              << "  --blocks BLOCKS        Number of bit blocks to use\n"
+              << "  --distance DISTANCE    Maximum bit distances of matches\n"
+              << "  --input INPUT          Path to input ('-' for stdin)\n"
+              << "  --output OUTPUT        Path to output ('-' for stdout)\n";
+}
+
+std::unordered_set<Simhash::hash_t> read_hashes(std::istream& stream)
+{
+    std::unordered_set<Simhash::hash_t> hashes;
+    for (std::string line; std::getline(stream, line); )
+    {
+        hashes.insert(std::stoull(line));
+    }
+    return hashes;
+}
+
+void write_clusters(std::ostream& stream, const Simhash::clusters_t& clusters)
+{
+    for (const auto& cluster : clusters)
+    {
+        auto it = cluster.begin();
+        stream << "[" << *(it++);
+        for (; it != cluster.end(); ++it)
+        {
+            stream << ", " << *it;
+        }
+        stream << "]\n";
+    }
+    stream.flush();
+}
+
+int main(int argc, char **argv) {
+
+    std::string input, output;
+    size_t blocks(0), distance(0);
+
+    int getopt_return_value(0);
+    while (getopt_return_value != -1)
+    {
+        int option_index = 0;
+        static struct option long_options[] = {
+            {"input",    required_argument, 0, 0 },
+            {"output",   required_argument, 0, 0 },
+            {"blocks",   required_argument, 0, 0 },
+            {"distance", required_argument, 0, 0 },
+            {"help",     no_argument,       0, 0 },
+            {0,          0,                 0, 0 }
+        };
+
+        getopt_return_value = getopt_long(
+            argc, argv, "i:o:b:d:h", long_options, &option_index);
+
+        switch(getopt_return_value)
+        {
+            case 0:
+                switch(option_index)
+                {
+                    case 0:
+                        input = optarg;
+                        break;
+                    case 1:
+                        output = optarg;
+                        break;
+                    case 2:
+                        std::stringstream(std::string(optarg)) >> blocks;
+                        break;
+                    case 3:
+                        std::stringstream(std::string(optarg)) >> distance;
+                        break;
+                    case 4:
+                        usage(argc, argv);
+                        return 0;
+                }
+                break;
+            case 'i':
+                input = optarg;
+                break;
+            case 'o':
+                output = optarg;
+                break;
+            case 'b':
+                std::stringstream(std::string(optarg)) >> blocks;
+                break;
+            case 'd':
+                std::stringstream(std::string(optarg)) >> distance;
+                break;
+            case 'h':
+                usage(argc, argv);
+                return 0;
+            case '?':
+                return 1;
+        }
+
+    }
+
+    if (blocks == 0)
+    {
+        std::cerr << "Blocks must be provided and > 0" << std::endl;
+        return 2;
+    }
+
+    if (distance == 0)
+    {
+        std::cerr << "Distance must be provided and > 0" << std::endl;
+        return 3;
+    }
+
+    if (input.empty())
+    {
+        std::cerr << "Input must be provided and non-empty." << std::endl;
+        return 4;
+    }
+
+    if (output.empty())
+    {
+        std::cerr << "Output must be provided and non-empty." << std::endl;
+        return 5;
+    }
+
+    if (blocks <= distance)
+    {
+        std::cerr << "Blocks (" << blocks << ") must be >= distance (" << distance << ")"
+                  << std::endl;
+        return 6;
+    }
+
+    // Read input
+    std::unordered_set<Simhash::hash_t> hashes;
+    if (input.compare("-") == 0)
+    {
+        std::cerr << "Reading hashes from stdin." << std::endl;
+        hashes = read_hashes(std::cin);
+    }
+    else
+    {
+        std::cerr << "Reading hashes from " << input << std::endl;
+        {
+            std::ifstream fin(input, std::ifstream::in | std::ifstream::binary);
+            if (!fin.good())
+            {
+                std::cerr << "Error reading " << input << std::endl;
+                return 7;
+            }
+            hashes = read_hashes(fin);
+        }
+    }
+
+    // Find matches
+    std::cerr << "Computing clusters..." << std::endl;
+    Simhash::clusters_t results = Simhash::find_clusters(hashes, blocks, distance);
+
+    // Write output
+    if (output.compare("-") == 0)
+    {
+        std::cerr << "Writing results to stdout." << std::endl;
+        write_clusters(std::cout, results);
+    }
+    else
+    {
+        std::cerr << "Writing results to " << output << std::endl;
+        {
+            std::ofstream fout(output, std::ofstream::binary);
+            if (!fout.good())
+            {
+                std::cerr << "Error writing " << output << std::endl;
+                return 8;
+            }
+            write_clusters(fout, results);
+        }
+    }
+
+    return 0;
+}

--- a/test/test-permutation.cpp
+++ b/test/test-permutation.cpp
@@ -22,13 +22,25 @@ TEST(PermutationTest, Choose3From6) {
 TEST(PermutationTest, ChooseTooMany)
 {
     std::vector<Simhash::hash_t> population = { 0, 1, 2, 3, 4, 5 };
-    // ASSERT_THROW(Simhash::Permutation::choose(population, 7), std::invalid_argument);
+    ASSERT_THROW(Simhash::Permutation::choose(population, 7), std::invalid_argument);
 }
 
 TEST(PermutationTest, Create)
 {
     std::vector<Simhash::Permutation> permutations = Simhash::Permutation::create(6, 3);
     EXPECT_EQ(20, permutations.size());
+}
+
+TEST(PermutationTest, CreateTooManyBlocks)
+{
+    ASSERT_THROW(
+        Simhash::Permutation::create(Simhash::BITS + 1, 3), std::invalid_argument);
+}
+
+TEST(PermutationTest, CreateTooFewBlocks)
+{
+    ASSERT_THROW(
+        Simhash::Permutation::create(2, 3), std::invalid_argument);
 }
 
 TEST(PermutationTest, Apply)

--- a/test/test-simhash.cpp
+++ b/test/test-simhash.cpp
@@ -1,5 +1,8 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <map>
+
 #include "simhash.h"
 
 TEST(NumDifferingBitsTest, Basic)
@@ -115,5 +118,79 @@ TEST(SimhashTest, FindAllDiverse)
     for (size_t blocks = 4; blocks < 10; ++blocks)
     {
         EXPECT_EQ(expected, Simhash::find_all(hashes, blocks, 3));
+    }
+}
+
+/**
+ * Turn a Simhash::clusters_t into a sorted vector of sorted clusters.
+ */
+std::vector<std::set<Simhash::hash_t> > sortClusters(const Simhash::clusters_t& clusters)
+{
+    // Comparator for sorting the results
+    struct {
+        bool operator() (
+            const std::set<Simhash::hash_t>& a,
+            const std::set<Simhash::hash_t> b)
+        {   
+            return min(a) < min(b);
+        }
+
+        Simhash::hash_t min(const std::set<Simhash::hash_t>& cluster)
+        {
+            return *(std::min_element(cluster.begin(), cluster.end()));
+        }
+    } comparator;
+
+    // Assign clusters to results
+    std::vector<std::set<Simhash::hash_t> > results;
+    for (const auto& cluster : clusters) {
+        results.push_back(std::set<Simhash::hash_t>(cluster.begin(), cluster.end()));
+    }
+
+    // Sort and return
+    std::sort(results.begin(), results.end(), comparator);
+    return results;
+}
+
+TEST(SimhashTest, FindClusters)
+{
+    std::unordered_set<Simhash::hash_t> hashes = {
+        0x000000FF, 0x000000EF, 0x000000EE, 0x000000CE, 0x00000033,
+        0x0000FF00, 0x0000EF00, 0x0000EE00, 0x0000CE00, 0x00003300,
+        0x00FF0000, 0x00EF0000, 0x00EE0000, 0x00CE0000, 0x00330000,
+        0xFF000000, 0xEF000000, 0xEE000000, 0xCE000000, 0x33000000
+    };
+    Simhash::clusters_t expected = {
+        { 0x000000FF, 0x000000EF, 0x000000EE, 0x000000CE },
+        { 0x0000FF00, 0x0000EF00, 0x0000EE00, 0x0000CE00 },
+        { 0x00FF0000, 0x00EF0000, 0x00EE0000, 0x00CE0000 },
+        { 0xFF000000, 0xEF000000, 0xEE000000, 0xCE000000 }
+    };
+    
+    for (size_t blocks = 4; blocks < 10; ++blocks)
+    {
+        auto actual = Simhash::find_clusters(hashes, blocks, 3);
+        EXPECT_EQ(sortClusters(expected), sortClusters(actual));
+    }
+}
+
+TEST(SimhashTest, FindClustersDiverse)
+{
+    std::unordered_set<Simhash::hash_t> hashes = {
+        0x00000000, 0x10101000, 0x10100010, 0x10001010, 0x00101010,
+                    0x01010100, 0x01010001, 0x01000101, 0x00010101
+    };
+
+    Simhash::clusters_t expected = {
+        {
+            0x00000000, 0x10101000, 0x10100010, 0x10001010, 0x00101010,
+                        0x01010100, 0x01010001, 0x01000101, 0x00010101
+        }
+    };
+
+    for (size_t blocks = 4; blocks < 10; ++blocks)
+    {
+        auto actual = Simhash::find_clusters(hashes, blocks, 3);
+        EXPECT_EQ(sortClusters(expected), sortClusters(actual));
     }
 }


### PR DESCRIPTION
Given @neilmb 's prototype, this is the C++ implementation.

The prototype used agglomerative hierarchical clustering, but used in a fashion to determine all the connected components in `O(n^2)` time in all cases. This approach finds the connected components directly with a time complexity of `O( d n ln(n) + E)`, where `d` is the number of blocks used, and E is the number of edges (matches) found in the hashes. Its worst case is `O(n^2)` when all simhashes are matches of all other simhashes. Working under the expectation that generally `E <<< n^2`, which is a large improvement in the common case.

I'd love to compare the perf to the same examples @neilmb ran, but for my test input (1.4M hashes, with 5.8k maches), it runs in 5 seconds.

@lindseyreno @tammybailey @asmidutz 