### PR TITLE
BIG-4444 Fix repeated clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ debug/libsimhash.o: debug/simhash.o debug/permutation.o
 debug/%.o: src/%.cpp include/%.h debug
 	$(CXX) $(CXXOPTS) $(DEBUG_OPTS) -o $@ -c $<
 
-debug/bin/%: src/bin/%.cpp debug/libsimhash.o debug/bin
+debug/bin/%: src/bin/%.cpp debug/libsimhash.o
 	mkdir -p debug/bin
 	$(CXX) $(CXXOPTS) $(DEBUG_OPTS) -o $@ $^
 

--- a/include/simhash.h
+++ b/include/simhash.h
@@ -37,7 +37,8 @@ namespace Simhash {
     /**
      * The type of a set of clusters.
      */
-    typedef std::vector<std::unordered_set<hash_t> > clusters_t;
+    typedef std::unordered_set<hash_t> cluster_t;
+    typedef std::vector<cluster_t> clusters_t;
 
     /**
      * The number of bits in a hash_t.

--- a/src/bin/simhash-find-clusters.cpp
+++ b/src/bin/simhash-find-clusters.cpp
@@ -137,7 +137,7 @@ int main(int argc, char **argv) {
 
     if (blocks <= distance)
     {
-        std::cerr << "Blocks (" << blocks << ") must be >= distance (" << distance << ")"
+        std::cerr << "Blocks (" << blocks << ") must be > distance (" << distance << ")"
                   << std::endl;
         return 6;
     }

--- a/src/simhash.cpp
+++ b/src/simhash.cpp
@@ -137,7 +137,7 @@ Simhash::clusters_t Simhash::find_clusters(
 
         // If a node has not been visited, then start a cluster emanating from it.
         visited[node.first] = true;
-        std::unordered_set<Simhash::hash_t> cluster({node.first});
+        Simhash::cluster_t cluster({node.first});
         std::list<Simhash::hash_t> frontier(node.second.begin(), node.second.end());
         while (!frontier.empty())
         {
@@ -145,6 +145,7 @@ Simhash::clusters_t Simhash::find_clusters(
             Simhash::hash_t neighbor = frontier.front();
             frontier.pop_front();
             cluster.insert(neighbor);
+            visited[neighbor] = true;
 
             // Put every unvisited neighbor in the frontier
             for (Simhash::hash_t hash : nodes[neighbor])

--- a/test/test-simhash.cpp
+++ b/test/test-simhash.cpp
@@ -194,3 +194,11 @@ TEST(SimhashTest, FindClustersDiverse)
         EXPECT_EQ(sortClusters(expected), sortClusters(actual));
     }
 }
+
+TEST(SimhashTest, FindClustersUnique)
+{
+    std::unordered_set<Simhash::hash_t> hashes = { 20, 10 };
+    Simhash::clusters_t expected = { { 10L, 20L } };
+    // 10 and 20 are 4 bits different
+    EXPECT_EQ(sortClusters(expected), sortClusters(Simhash::find_clusters(hashes, 5, 4)));
+}


### PR DESCRIPTION
This fixes a bug where the input simhashes `{ 10, 20 }` resulted in two clusters being output `[10, 20]` and `[20, 10]`. It was a simple programming error and I added a test case.

@tammybailey review for C++ please and @bfeigin for this being what you wanted.